### PR TITLE
Added ability to specify Windows logging location and rotation frequency

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -60,3 +60,18 @@ suites:
           acl_master_token: doublesecret
           acl_datacenter: fortmeade
           acl_default_policy: deny
+    excludes:
+      - centos-7.1
+      - windows-2012r2
+  - name: windefault
+    run_list:
+      - recipe[consul::default]
+    attributes:
+      consul:
+        service_user: vagrant
+        config: *default-config
+        service:
+          stdout_path: C:\foo\bar\out.log
+          stderr_path: C:\foo\bar\err.log
+    includes:
+      - windows-2012r2

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,6 +40,12 @@ default['consul']['service']['binary_url'] = "https://releases.hashicorp.com/con
 
 default['consul']['service']['source_url'] = 'https://github.com/hashicorp/consul'
 
+if node['os'] == 'windows'
+  default['consul']['service']['stdout_path'] = join_path prefix_path, 'stdout.log'
+  default['consul']['service']['stderr_path'] = join_path prefix_path, 'stderr.log'
+  default['consul']['service']['logrotate_frequency'] = 86_400
+end
+
 default['consul']['version'] = '0.6.0'
 default['consul']['checksums'] = {
   'consul_0.5.0_darwin_amd64'  => '24d9758c873e9124e0ce266f118078f87ba8d8363ab16c2e59a3cd197b77e964',

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -65,6 +65,18 @@ module ConsulCookbook
       # @!attribute config_dir
       # @return [String]
       attribute(:config_dir, kind_of: String, default: lazy { node['consul']['config']['config_dir'] })
+
+      # @!attribute stdout_path
+      # @return [String]
+      attribute(:stdout_path, kind_of: String, default: lazy { node['consul']['service']['stdout_path'] })
+
+      # @!attribute stderr_path
+      # @return [String]
+      attribute(:stderr_path, kind_of: String, default: lazy { node['consul']['service']['stderr_path'] })
+
+      # @!attribute logrotate_frequency
+      # @return [String]
+      attribute(:logrotate_frequency, kind_of: Integer, default: lazy { node['consul']['service']['logrotate_frequency'] })
     end
   end
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,14 @@
 require 'serverspec'
 
-set :backend, :exec
+
+def windows?
+  (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+end
+
+if !windows?
+  set :backend, :exec
+else
+  set :backend, :cmd
+  set :os, :family => 'windows'
+  set :architecture, :x86_64
+end

--- a/test/integration/windefault/serverspec/localhost/logging_spec.rb
+++ b/test/integration/windefault/serverspec/localhost/logging_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+context 'logging' do
+  describe file('C:\foo\bar\out.log') do
+    it { should be_file }
+  end
+
+  describe file('C:\foo\bar\err.log') do
+    it { should be_file }
+  end
+end


### PR DESCRIPTION
Most people can use the standard logging, but we have a company policy on where to store log files on Windows. This lets us use that location; most people probably won't need to override the default.